### PR TITLE
change header of boundary condition files

### DIFF
--- a/0deg/2/U
+++ b/0deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/0deg/2/epsilon
+++ b/0deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/0deg/2/k
+++ b/0deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/0deg/2/p
+++ b/0deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/120deg/2/U
+++ b/120deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/120deg/2/epsilon
+++ b/120deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/120deg/2/k
+++ b/120deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/120deg/2/p
+++ b/120deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/150deg/2/U
+++ b/150deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/150deg/2/epsilon
+++ b/150deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/150deg/2/k
+++ b/150deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/150deg/2/p
+++ b/150deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/180deg/2/U
+++ b/180deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/180deg/2/epsilon
+++ b/180deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/180deg/2/k
+++ b/180deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/180deg/2/p
+++ b/180deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/210deg/2/U
+++ b/210deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/210deg/2/epsilon
+++ b/210deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/210deg/2/k
+++ b/210deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/210deg/2/p
+++ b/210deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/240deg/2/U
+++ b/240deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/240deg/2/epsilon
+++ b/240deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/240deg/2/k
+++ b/240deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/240deg/2/p
+++ b/240deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/270deg/2/U
+++ b/270deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/270deg/2/epsilon
+++ b/270deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/270deg/2/k
+++ b/270deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/270deg/2/p
+++ b/270deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/300deg/2/U
+++ b/300deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/300deg/2/epsilon
+++ b/300deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/300deg/2/k
+++ b/300deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/300deg/2/p
+++ b/300deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/30deg/2/U
+++ b/30deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/30deg/2/epsilon
+++ b/30deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/30deg/2/k
+++ b/30deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/30deg/2/p
+++ b/30deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/330deg/2/U
+++ b/330deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/330deg/2/epsilon
+++ b/330deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/330deg/2/k
+++ b/330deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/330deg/2/p
+++ b/330deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/60deg/2/U
+++ b/60deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/60deg/2/epsilon
+++ b/60deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/60deg/2/k
+++ b/60deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/60deg/2/p
+++ b/60deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/90deg/2/U
+++ b/90deg/2/U
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 1 -1 0 0 0 0];
 

--- a/90deg/2/epsilon
+++ b/90deg/2/epsilon
@@ -17,7 +17,7 @@ FoamFile
 
 dimensions      [0 2 -3 0 0 0 0];
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 internalField   uniform $epsilonInlet;
 

--- a/90deg/2/k
+++ b/90deg/2/k
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 

--- a/90deg/2/p
+++ b/90deg/2/p
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#include        "include/ABLConditions"
+#include        "include/initialConditions"
 
 dimensions      [0 2 -2 0 0 0 0];
 


### PR DESCRIPTION
Hi,

Thanks for publishing this. I was wondering if the first line in the ```U``` ,```k```,```epsilon```, and ```p``` files should be changed to:

```cpp
#include "include/initialConditions"
```

currently it is set to

```cpp
#include "include/ABLConditions"
```

Here is a pull request changing all of these.

-Andres